### PR TITLE
Add support for unicode strings

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -81,7 +81,7 @@ typeDefinition
     'is'  elementaryTypeName ';' ;
 
 usingForDeclaration
-  : 'using' identifier 'for' ('*' | typeName) ';' ;
+  : 'using' userDefinedTypeName 'for' ('*' | typeName) ';' ;
 
 structDefinition
   : 'struct' identifier

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -80,7 +80,7 @@ structDefinition
     '{' ( variableDeclaration ';' (variableDeclaration ';')* )? '}' ;
 
 modifierDefinition
-  : 'modifier' identifier parameterList? ( VirtualKeyword | overrideSpecifier )* block ;
+  : 'modifier' identifier parameterList? ( VirtualKeyword | overrideSpecifier )* ( ';' | block ) ;
 
 modifierInvocation
   : identifier ( '(' expressionList? ')' )? ;

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -484,8 +484,8 @@ stringLiteral
   : StringLiteralFragment+ ;
 
 StringLiteralFragment
-  : '"' DoubleQuotedStringCharacter* '"'
-  | '\'' SingleQuotedStringCharacter* '\'' ;
+  : 'unicode'? '"' DoubleQuotedStringCharacter* '"'
+  | 'unicode'? '\'' SingleQuotedStringCharacter* '\'' ;
 
 fragment
 DoubleQuotedStringCharacter

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -39,9 +39,11 @@ importDeclaration
   : identifier ('as' identifier)? ;
 
 importDirective
-  : 'import' StringLiteralFragment ('as' identifier)? ';'
-  | 'import' ('*' | identifier) ('as' identifier)? 'from' StringLiteralFragment ';'
-  | 'import' '{' importDeclaration ( ',' importDeclaration )* '}' 'from' StringLiteralFragment ';' ;
+  : 'import' importPath ('as' identifier)? ';'
+  | 'import' ('*' | identifier) ('as' identifier)? 'from' importPath ';'
+  | 'import' '{' importDeclaration ( ',' importDeclaration )* '}' 'from' importPath ';' ;
+
+importPath : StringLiteralFragment ;
 
 contractDefinition
   : 'abstract'? ( 'contract' | 'interface' | 'library' ) identifier

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -250,7 +250,7 @@ Ufixed
 expression
   : expression ('++' | '--')
   | 'new' typeName
-  | expression '[' expression? ']'
+  | expression '[' expression ']'
   | expression '[' expression? ':' expression? ']'
   | expression '.' identifier
   | expression '{' nameValueList '}'

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -14,6 +14,7 @@ sourceUnit
     | functionDefinition
     | fileLevelConstant
     | customErrorDefinition
+    | typeDefinition
     )* EOF ;
 
 pragmaDirective
@@ -61,7 +62,8 @@ contractPart
   | functionDefinition
   | eventDefinition
   | enumDefinition
-  | customErrorDefinition;
+  | customErrorDefinition
+  | typeDefinition;
 
 stateVariableDeclaration
   : typeName
@@ -73,6 +75,10 @@ fileLevelConstant
 
 customErrorDefinition
   : 'error' identifier parameterList ';' ;
+
+typeDefinition
+  : 'type' identifier
+    'is'  elementaryTypeName ';' ;
 
 usingForDeclaration
   : 'using' identifier 'for' ('*' | typeName) ';' ;

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -353,13 +353,15 @@ assemblyCall
   : ( 'return' | 'address' | 'byte' | identifier ) ( '(' assemblyExpression? ( ',' assemblyExpression )* ')' )? ;
 
 assemblyLocalDefinition
-  : 'let' assemblyIdentifierOrList ( ':=' assemblyExpression )? ;
+  : 'let' assemblyIdentifier ( ':=' assemblyExpression )?
+  | 'let' assemblyIdentifierList ( ':=' assemblyCall )? ;
 
 assemblyAssignment
-  : assemblyIdentifierOrList ':=' assemblyExpression ;
+  : assemblyIdentifier ':=' assemblyExpression
+  | assemblyIdentifierList ':=' assemblyCall;
 
-assemblyIdentifierOrList
-  : identifier | assemblyMember | '(' assemblyIdentifierList ')' ;
+assemblyIdentifier
+  : identifier | assemblyMember;
 
 assemblyIdentifierList
   : identifier ( ',' identifier )* ;

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -13,6 +13,7 @@ sourceUnit
     | structDefinition
     | functionDefinition
     | fileLevelConstant
+    | customErrorDefinition
     )* EOF ;
 
 pragmaDirective
@@ -57,7 +58,8 @@ contractPart
   | modifierDefinition
   | functionDefinition
   | eventDefinition
-  | enumDefinition ;
+  | enumDefinition
+  | customErrorDefinition;
 
 stateVariableDeclaration
   : typeName
@@ -66,6 +68,9 @@ stateVariableDeclaration
 
 fileLevelConstant
   : typeName ConstantKeyword identifier '=' expression ';' ;
+
+customErrorDefinition
+  : 'error' identifier parameterList ';' ;
 
 usingForDeclaration
   : 'using' identifier 'for' ('*' | typeName) ';' ;
@@ -171,7 +176,8 @@ statement
   | throwStatement
   | emitStatement
   | simpleStatement
-  | uncheckedStatement;
+  | uncheckedStatement
+  | revertStatement;
 
 expressionStatement
   : expression ';' ;
@@ -219,6 +225,9 @@ throwStatement
 
 emitStatement
   : 'emit' functionCall ';' ;
+
+revertStatement
+  : 'revert' functionCall ';' ;
 
 variableDeclarationStatement
   : ( 'var' identifierList | variableDeclaration | '(' variableDeclarationList ')' ) ( '=' expression )? ';';
@@ -391,8 +400,10 @@ typeNameExpression
 numberLiteral
   : (DecimalNumber | HexNumber) NumberUnit? ;
 
+// some keywords need to be added here to avoid ambiguities
+// for example, "revert" is a keyword but it can also be a function name
 identifier
-  : ('from' | 'calldata' | 'receive' | 'callback' | ConstructorKeyword | PayableKeyword | LeaveKeyword | Identifier) ;
+  : ('from' | 'calldata' | 'receive' | 'callback' | 'revert' | 'error' | ConstructorKeyword | PayableKeyword | LeaveKeyword | Identifier) ;
 
 BooleanLiteral
   : 'true' | 'false' ;

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -392,7 +392,7 @@ numberLiteral
   : (DecimalNumber | HexNumber) NumberUnit? ;
 
 identifier
-  : ('from' | 'calldata' | 'receive' | 'callback' | PayableKeyword | LeaveKeyword | Identifier) ;
+  : ('from' | 'calldata' | 'receive' | 'callback' | ConstructorKeyword | PayableKeyword | LeaveKeyword | Identifier) ;
 
 BooleanLiteral
   : 'true' | 'false' ;

--- a/test.sol
+++ b/test.sol
@@ -841,3 +841,8 @@ contract WithUncheckedBlock {
     return x;
   }
 }
+
+contract UnicodeStrings {
+  string a = unicode"Hello 😃";
+  string b = unicode'Hello 😃';
+}

--- a/test.sol
+++ b/test.sol
@@ -846,3 +846,11 @@ contract UnicodeStrings {
   string a = unicode"Hello 😃";
   string b = unicode'Hello 😃';
 }
+
+contract ArraySlices {
+    function f(bytes calldata x) public {
+        bytes memory a1 = abi.decode(x[:], (bytes));
+        bytes4 a2 = abi.decode(x[:4], (bytes4));
+        address a3 = abi.decode(x[4:], (address));
+    }
+}

--- a/test.sol
+++ b/test.sol
@@ -886,3 +886,8 @@ library FixedMath {
         return UFixed.wrap(a * multiplier);
     }
 }
+
+// issue #59
+contract C {
+  using L.Lib for uint;
+}

--- a/test.sol
+++ b/test.sol
@@ -854,3 +854,35 @@ contract ArraySlices {
         address a3 = abi.decode(x[4:], (address));
     }
 }
+
+// User defined value types
+type Price is uint128;
+type Quantity is uint128;
+
+contract Foo {
+  type Id is uint8;
+
+  Id public id;
+}
+
+type UFixed is uint256;
+
+library FixedMath {
+    uint constant multiplier = 10**18;
+
+    function add(UFixed a, UFixed b) internal pure returns (UFixed) {
+        return UFixed.wrap(UFixed.unwrap(a) + UFixed.unwrap(b));
+    }
+
+    function mul(UFixed a, uint256 b) internal pure returns (UFixed) {
+        return UFixed.wrap(UFixed.unwrap(a) * b);
+    }
+
+    function floor(UFixed a) internal pure returns (uint256) {
+        return UFixed.unwrap(a) / multiplier;
+    }
+
+    function toUFixed(uint256 a) internal pure returns (UFixed) {
+        return UFixed.wrap(a * multiplier);
+    }
+}

--- a/test.sol
+++ b/test.sol
@@ -480,7 +480,7 @@ contract test {
 			// function dispatcher
 			switch div(calldataload(0), exp(2, 226))
 			case 0xb3de648b {
-				let (r) := f(calldataload(4))
+				let r := f(calldataload(4))
 				let ret := $allocate(0x20)
 				mstore(ret, r)
 				return(ret, 0x20)
@@ -890,4 +890,20 @@ library FixedMath {
 // issue #59
 contract C {
   using L.Lib for uint;
+}
+
+// issue #60
+contract AssemblyAssingment {
+    function foo() public pure {
+        assembly {
+            function bar() -> a, b {
+                a := 1
+                b := 2
+            }
+
+            let i, j
+            let k, l := bar()
+            i, j := bar()
+        }
+    }
 }


### PR DESCRIPTION
The existing rule doesn't allow to assign values to a list of
variables without using parentheses.

The existing rule doesn't also enforce the rule that multi-assignments
can be used only with values returned by a function call.

I've updated both `assemblyLocalDefinition` and `assemblyAssignment`
to allow multi-assignments only before a function call and I've also
removed the ability to wrap a list of identifiers with parentheses
because that doesn't look to be supported anymore.

See [ethereum/solidity/blob/develop/docs/grammar/SolidityParser.g4](https://github.com/ethereum/solidity/blob/47d77931747aba8e364452537d989b795df7ca04/docs/grammar/SolidityParser.g4#L526-L538)

Closes solidity-parser/parser#60